### PR TITLE
feat/shop backoffice

### DIFF
--- a/shop-backoffice/.local.env
+++ b/shop-backoffice/.local.env
@@ -1,1 +1,0 @@
-ENVIRONMENT=

--- a/shop-backoffice/README.md
+++ b/shop-backoffice/README.md
@@ -1,0 +1,59 @@
+# Shop-Backoffice
+
+## Rotas Disponíveis:
+    POST /backoffice/products
+    GET /backoffice/health/status
+
+#### Exemplos de rotas:
+    POST http://localhost:8081/backoffice/products
+    Content-Type: application/json
+    correlationId: "30eb2105-f4cc-49e0-95e8-04da1eca3737"
+    traceId: "30eb2105"
+    flowId: "99882992"
+
+    {
+        "nome": "NEW",
+        "departamento": "Informatica",
+        "tags": ["Informatica","Notebook","Acessorios","Home-Office", "Promocao"],
+        "preco": 1500000,
+        "quantidade": 9,
+        "ativo": true
+    }
+
+    GET http://localhost:8081/backoffice/health/status
+
+#### Curl Rotas:
+    curl --request GET \
+    --url http://localhost:8081/backoffice/health/status
+
+    curl --request POST \
+    --url http://localhost:8081/backoffice/products \
+    --header 'Content-Type: application/json' \
+    --header 'correlationId: 4e41452c-35e4-44f8-ad02-506328a563bb' \
+    --header 'flowId: de2c47b9-84a6-4caa-b540-ecab00e72ab4' \
+    --header 'traceId: 0307f376-d0c4-471a-afe1-dca1b39abf4e' \
+    --data '{
+        "nome": "Celular",
+        "departamento": "Informatica",
+        "tags": ["Informatica","Notebook","Acessorios","Home-Office", "Promocao"],
+        "preco": 1500000,
+        "quantidade": 9,
+        "ativo": true
+    }'
+
+## Como rodar a aplicação:
+    Rodar o arquivo docker-compose.yaml, ele será responsável por subir o dynamo e a aplicação na port 8081. Caso a variável de ambiente ENVIRONMENT não tenha sido setada, a aplicação se comunicará com o dynamo iniciado via docker e na inicialização tentará fazer a criação da tabela Products, de forma automática.
+
+## Stack da Aplicação:
+    GO
+    GIN
+    AWS DynamoDB
+    Arquitetura Hexagonal/Limpa
+
+## Dependências diretas da Aplicação:
+    GIN (github.com/aws/aws-sdk-go)
+    AWS (github.com/gin-gonic/gin)
+    GOOGLE UUID (github.com/google/uuid)
+    TESTIFY (github.com/stretchr/testify)
+    MOCKGEN (go.uber.org/mock)
+    CONTEXTCORRELATIONHANDLER (github.com/hugovallada/correlationcontexthandler)

--- a/shop-backoffice/docker-compose.yaml
+++ b/shop-backoffice/docker-compose.yaml
@@ -7,6 +7,12 @@ services:
     command: "-jar DynamoDBLocal.jar -sharedDb"
     volumes:
       - dynamodb_data:/dynamodblocal
+  shop-poc:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8081:8081"
 
 volumes:
   dynamodb_data:

--- a/shop-backoffice/docker-compose.yaml
+++ b/shop-backoffice/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     command: "-jar DynamoDBLocal.jar -sharedDb"
     volumes:
       - dynamodb_data:/dynamodblocal
-  shop-poc:
+  shop-backoffice:
     build:
       context: .
       dockerfile: Dockerfile

--- a/shop-backoffice/go.mod
+++ b/shop-backoffice/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/google/uuid v1.6.0
 	github.com/hugovallada/correlationcontexthandler v0.0.0-20240523010538-5db3f858c585
-	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/mock v0.4.0
 )

--- a/shop-backoffice/go.sum
+++ b/shop-backoffice/go.sum
@@ -38,8 +38,6 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
-github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/shop-backoffice/infra/config/db/dynamo_db_config.go
+++ b/shop-backoffice/infra/config/db/dynamo_db_config.go
@@ -14,56 +14,17 @@ func ConfigDynamoDB() *dynamodb.DynamoDB {
 
 func ConfigDynamoDBLocal() *dynamodb.DynamoDB {
 	dynamoClient := dynamodb.New(prepareLocalSess())
-	_, err := dynamoClient.DescribeTable(&dynamodb.DescribeTableInput{
-		TableName: aws.String("Products"),
-	})
-	if err != nil {
-		_, err := dynamoClient.CreateTable(&dynamodb.CreateTableInput{
-			TableName: aws.String("Products"),
-			KeySchema: []*dynamodb.KeySchemaElement{
-				{
-					AttributeName: aws.String("id"),
-					KeyType:       aws.String("HASH"),
-				},
-			},
-			AttributeDefinitions: []*dynamodb.AttributeDefinition{
-				{
-					AttributeName: aws.String("id"),
-					AttributeType: aws.String("S"),
-				},
-				{
-					AttributeName: aws.String("name"),
-					AttributeType: aws.String("S"),
-				},
-			},
-			ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
-				ReadCapacityUnits:  aws.Int64(5),
-				WriteCapacityUnits: aws.Int64(5),
-			},
-			GlobalSecondaryIndexes: []*dynamodb.GlobalSecondaryIndex{
-				{
-					IndexName: aws.String("name_gsi"),
-					KeySchema: []*dynamodb.KeySchemaElement{
-						{
-							AttributeName: aws.String("name"),
-							KeyType:       aws.String("HASH"),
-						},
-					},
-					Projection: &dynamodb.Projection{
-						ProjectionType: aws.String("ALL"),
-					},
-					ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
-						ReadCapacityUnits:  aws.Int64(5),
-						WriteCapacityUnits: aws.Int64(5),
-					},
-				},
-			},
-		})
-		if err != nil {
-			slog.Error("Não foi possível configurar a tabela, será necessário criar manualmente", slog.Any("error", err.Error()))
-		}
+	if _, err := dynamoClient.DescribeTable(&dynamodb.DescribeTableInput{TableName: aws.String("Products")}); err != nil {
+		slog.Info("Tabela 'Products' não existe.Tentando criar tabela...")
+		createTableProducts(dynamoClient)
 	}
 	return dynamoClient
+}
+
+func prepareSess() *session.Session {
+	return session.Must(session.NewSession(&aws.Config{
+		Region: aws.String("sa-east-1"),
+	}))
 }
 
 func prepareLocalSess() *session.Session {
@@ -73,8 +34,51 @@ func prepareLocalSess() *session.Session {
 	}))
 }
 
-func prepareSess() *session.Session {
-	return session.Must(session.NewSession(&aws.Config{
-		Region: aws.String("sa-east-1"),
-	}))
+func createTableProducts(dynamoClient *dynamodb.DynamoDB) {
+	_, err := dynamoClient.CreateTable(&dynamodb.CreateTableInput{
+		TableName: aws.String("Products"),
+		KeySchema: []*dynamodb.KeySchemaElement{
+			{
+				AttributeName: aws.String("id"),
+				KeyType:       aws.String("HASH"),
+			},
+		},
+		AttributeDefinitions: []*dynamodb.AttributeDefinition{
+			{
+				AttributeName: aws.String("id"),
+				AttributeType: aws.String("S"),
+			},
+			{
+				AttributeName: aws.String("name"),
+				AttributeType: aws.String("S"),
+			},
+		},
+		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+			ReadCapacityUnits:  aws.Int64(5),
+			WriteCapacityUnits: aws.Int64(5),
+		},
+		GlobalSecondaryIndexes: []*dynamodb.GlobalSecondaryIndex{
+			{
+				IndexName: aws.String("name_gsi"),
+				KeySchema: []*dynamodb.KeySchemaElement{
+					{
+						AttributeName: aws.String("name"),
+						KeyType:       aws.String("HASH"),
+					},
+				},
+				Projection: &dynamodb.Projection{
+					ProjectionType: aws.String("ALL"),
+				},
+				ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+					ReadCapacityUnits:  aws.Int64(5),
+					WriteCapacityUnits: aws.Int64(5),
+				},
+			},
+		},
+	})
+	if err != nil {
+		slog.Error("Não foi possível configurar a tabela, será necessário criar manualmente", slog.Any("error", err.Error()))
+		return
+	}
+	slog.Info("Tabela 'Products' criada com sucesso.")
 }

--- a/shop-backoffice/infra/config/db/dynamo_db_config.go
+++ b/shop-backoffice/infra/config/db/dynamo_db_config.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"log/slog"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -11,7 +13,57 @@ func ConfigDynamoDB() *dynamodb.DynamoDB {
 }
 
 func ConfigDynamoDBLocal() *dynamodb.DynamoDB {
-	return dynamodb.New(prepareLocalSess())
+	dynamoClient := dynamodb.New(prepareLocalSess())
+	_, err := dynamoClient.DescribeTable(&dynamodb.DescribeTableInput{
+		TableName: aws.String("Products"),
+	})
+	if err != nil {
+		_, err := dynamoClient.CreateTable(&dynamodb.CreateTableInput{
+			TableName: aws.String("Products"),
+			KeySchema: []*dynamodb.KeySchemaElement{
+				{
+					AttributeName: aws.String("id"),
+					KeyType:       aws.String("HASH"),
+				},
+			},
+			AttributeDefinitions: []*dynamodb.AttributeDefinition{
+				{
+					AttributeName: aws.String("id"),
+					AttributeType: aws.String("S"),
+				},
+				{
+					AttributeName: aws.String("name"),
+					AttributeType: aws.String("S"),
+				},
+			},
+			ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+				ReadCapacityUnits:  aws.Int64(5),
+				WriteCapacityUnits: aws.Int64(5),
+			},
+			GlobalSecondaryIndexes: []*dynamodb.GlobalSecondaryIndex{
+				{
+					IndexName: aws.String("name_gsi"),
+					KeySchema: []*dynamodb.KeySchemaElement{
+						{
+							AttributeName: aws.String("name"),
+							KeyType:       aws.String("HASH"),
+						},
+					},
+					Projection: &dynamodb.Projection{
+						ProjectionType: aws.String("ALL"),
+					},
+					ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+						ReadCapacityUnits:  aws.Int64(5),
+						WriteCapacityUnits: aws.Int64(5),
+					},
+				},
+			},
+		})
+		if err != nil {
+			slog.Error("Não foi possível configurar a tabela, será necessário criar manualmente", slog.Any("error", err.Error()))
+		}
+	}
+	return dynamoClient
 }
 
 func prepareLocalSess() *session.Session {
@@ -23,7 +75,6 @@ func prepareLocalSess() *session.Session {
 
 func prepareSess() *session.Session {
 	return session.Must(session.NewSession(&aws.Config{
-		Region:   aws.String("sa-east-1"),
-		Endpoint: aws.String("http://localhost:8000"),
+		Region: aws.String("sa-east-1"),
 	}))
 }

--- a/shop-backoffice/infra/config/db/dynamo_db_config_factory.go
+++ b/shop-backoffice/infra/config/db/dynamo_db_config_factory.go
@@ -1,11 +1,14 @@
 package db
 
 import (
+	"slices"
+
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 func BuildDynamoDBConfig(environment string) *dynamodb.DynamoDB {
-	if environment == "local" {
+	cloudEnvironments := []string{"dev", "hom", "prod"}
+	if !slices.Contains(cloudEnvironments, environment) {
 		return ConfigDynamoDBLocal()
 	} else {
 		return ConfigDynamoDB()

--- a/shop-backoffice/main.go
+++ b/shop-backoffice/main.go
@@ -16,12 +16,18 @@ import (
 	"github.com/hugovallada/shop-poc/shop-backoffice/infra/config/db"
 	"github.com/hugovallada/shop-poc/shop-backoffice/infra/config/logs"
 	"github.com/hugovallada/shop-poc/shop-backoffice/infra/data"
-	"github.com/joho/godotenv"
+)
+
+var (
+	env string
 )
 
 func init() {
 	logs.SetDefaultSlogHandler()
-	_ = godotenv.Load()
+	env = os.Getenv("ENVIRONMENT")
+	if env == "" {
+		env = "local"
+	}
 }
 
 func main() {
@@ -41,7 +47,6 @@ func main() {
 }
 
 func initCreateProductController() controller.CreateProductController {
-	env := os.Getenv("ENVIRONMENT")
 	slog.Info("Initializing dependencies for environment " + env)
 	var persistPort outputPort.PersistProductOutputPort
 	productRepository := data.NewProductRepository(*db.BuildDynamoDBConfig(env))


### PR DESCRIPTION
- **Inicio desenvolvimento da camada de dominio: Entidade, DTOS, Usecases e teste entidade**
- **Implementa o usecase e cria testes unitarios com mocks**
- **Cria interface para o usecase**
- **Adiciona rota inicial para criar produtos**
- **Configura slog na aplicação com padrão JSON**
- **Adiciona grupo de rotas na aplicação**
- **Adiciona payload de request**
- **Adiciona exemplo de validacao manual. Possivelmente sera substituido pelo package validator/v10**
- **Passa pelo fluxo completo usando mock no adapter do banco**
- **Separa a inicialização de dependencias**
- **Cria adapter e repository para o dynamo**
- **Adiciona endpoint actuator**
- **Adiciona loadenv, para inicializar adapter por ambiente**
- **Adiciona middleware de duração, para preparar para uso do prometheus**
- **Melhoria nome de variavel**
- **Adiciona multistage build Dockerfile**
- **Ajuste regra de negócio e adição de docker compose para o dynamo**
- **Adiciona contexto e log do correlation**
- **Separa a inicializaçõ do log em uma função**
- **Adiciona biblioteca de context**
- **Retorna a configuração separada de logs**
- **Ajuste para usar o contexthandler**
- **Adiciona o mockgen e cria teste adapter**
- **Adiciona método para buscar pelo nome/GSI**
- **Adiciona busca por produto via nome**
- **Ajuste CreatedAt field**
- **Limita o retorno do dynamo em 2**
- **Validação para verificar e realmente está havendo uma atualização**
- **Adiciona a criação local da tabela na configuração local**
